### PR TITLE
add event filter and set rabbitmq args

### DIFF
--- a/src/.example.env
+++ b/src/.example.env
@@ -35,8 +35,7 @@ POSTGRES_DB=
 
 # sqlalchemy config
 DB_URL=postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-
-# rebbitmq config
+# rabbitmq config
 RMQ_USERNAME=
 RMQ_PASSWORD=
 # 127.0.0.1 or rabbitmq(docker)

--- a/src/app/calendars/caldav_searchers.py
+++ b/src/app/calendars/caldav_searchers.py
@@ -2,9 +2,9 @@ from ..async_wraps.async_wrap_caldav import caldav_search
 from ..calendars.conference import Conference
 
 from datetime import datetime
-from caldav import Calendar
+from caldav import Calendar, Event
 import asyncio
-from typing import AsyncGenerator, Sequence
+from typing import AsyncGenerator, Sequence, Generator
 
 
 async def find_conferences_in_some_cals(
@@ -23,12 +23,19 @@ async def find_conferences_in_one_cal(
         cal: Calendar,
         dates: tuple[datetime, datetime],
 ) -> tuple[Calendar, Sequence[Conference]] | None:
-    tz = str(dates[0].tzinfo)
     events = await caldav_search(cal, event=True, start=dates[0], end=dates[1], sort_keys=('dtstart',))
 
-    conferences = [
-        Conference(e.icalendar_component, tz) for e in events if e.icalendar_component.get("X-TELEMOST-CONFERENCE")
-    ]
+    conferences = [i for i in event_filter(events, dates[0], dates[1])]
 
     if conferences:
         return cal, conferences
+
+
+def event_filter(events: list[Event], dtstart: datetime, dtend: datetime) -> Generator[Conference, None, None]:
+    for e in events:
+        icalendar_component = e.icalendar_component
+        if icalendar_component.get("X-TELEMOST-CONFERENCE"):
+            tz = str(dtstart.tzinfo)
+            conf = Conference(icalendar_component, tz)
+            if dtstart <= datetime.fromisoformat(conf.dtstart) and dtend >= datetime.fromisoformat(conf.dtend):
+                yield conf

--- a/src/rmq/compose.yaml
+++ b/src/rmq/compose.yaml
@@ -10,4 +10,4 @@ services:
       - RABBITMQ_DEFAULT_USER=guest
       - RABBITMQ_DEFAULT_PASS=guest
       - RABBITMQ_DEFAULT_VHOST=my_vhost
-      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit disk_free_limit 1147483648
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit disk_free_limit 1147483648 heartbeat 0 consumer_timeout 36000000


### PR DESCRIPTION
1)
fix error: Pika connection lost Error: pika.exceptions.StreamLostError: Stream connection lost: ConnectionResetError(104, 'Connection reset by peer') set heartbeat=0
2)
fix incorrect method `calendar.search`
create custom generator `event_filter` which yield Conference instance if dtstart and dtend in between search 3)
3)
rewrite mistake in words `.example.env`